### PR TITLE
chore: plugin path in base

### DIFF
--- a/packages/backend-adapter-argonauts/package.json
+++ b/packages/backend-adapter-argonauts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@xyng/yuoshi-backend-adapter-argonauts",
-	"version": "0.0.2-beta.0",
+	"version": "0.0.2-beta.1",
 	"description": "",
 	"repository": {
 		"type": "git",
@@ -23,7 +23,7 @@
 	"author": "Daniel Melchior",
 	"license": "MIT",
 	"dependencies": {
-		"@xyng/yuoshi-backend-adapter": "^0.0.2-beta.0"
+		"@xyng/yuoshi-backend-adapter": "^0.0.2-beta.1"
 	},
 	"devDependencies": {
 		"@rollup/plugin-commonjs": "^11.0.1",

--- a/packages/backend-adapter-argonauts/src/adapters/CourseAdapter.ts
+++ b/packages/backend-adapter-argonauts/src/adapters/CourseAdapter.ts
@@ -40,7 +40,7 @@ export default class CourseAdapter<
 	getCourses(user_id: string): Paginator<Course, RequestBackendConfigType> {
     	return new Paginator<Course, RequestBackendConfigType>(
     		config => {
-    			return this.requestAdapter.getAuthorized(`plugins.php/argonautsplugin/users/${user_id}/courses`, config)
+    			return this.requestAdapter.getAuthorized(`/users/${user_id}/courses`, config)
 			},
 			mapCourseData(this.backendAdapter as BackendAdapter<RequestBackendConfigType>)
 		)
@@ -60,7 +60,7 @@ export default class CourseAdapter<
 				}
 
     			return this.requestAdapter.getAuthorized(
-    				`plugins.php/argonautsplugin/courses/${course_id}/memberships`,
+    				`/courses/${course_id}/memberships`,
 					config
 				)
 			},

--- a/packages/backend-adapter-argonauts/src/adapters/PackageAdapter.ts
+++ b/packages/backend-adapter-argonauts/src/adapters/PackageAdapter.ts
@@ -9,7 +9,7 @@ export default class PackageAdapter<
 	getPackagesForCourse(course_id: string): Paginator<NSPackageAdapter.Package, any> {
 		return new Paginator<NSPackageAdapter.Package, RequestBackendConfigType>(
     		config => {
-				return this.requestAdapter.getAuthorized(`plugins.php/argonautsplugin/courses/${course_id}/packages`, config)
+				return this.requestAdapter.getAuthorized(`/courses/${course_id}/packages`, config)
 			},
 			(data) => {
     			return {

--- a/packages/backend-adapter-argonauts/src/adapters/TaskAdapter.ts
+++ b/packages/backend-adapter-argonauts/src/adapters/TaskAdapter.ts
@@ -16,7 +16,7 @@ export default class TaskAdapter<
 				}
 			})
 
-			return this.requestAdapter.getAuthorized(`plugins.php/argonautsplugin/packages/${package_id}/tasks`, config)
+			return this.requestAdapter.getAuthorized(`/packages/${package_id}/tasks`, config)
 		}, (data) => {
 			return {
 				id: data.id,
@@ -33,7 +33,7 @@ export default class TaskAdapter<
 	}
 
 	async _getNextTask(package_id: string): Promise<ApiTask|undefined> {
-		const { data: { data } } = await this.requestAdapter.getAuthorized(`plugins.php/argonautsplugin/packages/${package_id}/nextTask`)
+		const { data: { data } } = await this.requestAdapter.getAuthorized(`/packages/${package_id}/nextTask`)
 
 		if (!data) {
 			return undefined;
@@ -53,7 +53,7 @@ export default class TaskAdapter<
     }
 
     async _getTask(task_id: string): Promise<ApiTask|undefined> {
-		const { data: { data } } = await this.requestAdapter.getAuthorized(`plugins.php/argonautsplugin/tasks/${task_id}`)
+		const { data: { data } } = await this.requestAdapter.getAuthorized(`/tasks/${task_id}`)
 
 		if (!data) {
 			return undefined;

--- a/packages/backend-adapter-argonauts/src/adapters/TaskContentAdapter.ts
+++ b/packages/backend-adapter-argonauts/src/adapters/TaskContentAdapter.ts
@@ -9,7 +9,7 @@ export default class TaskContentAdapter<
 > extends NSTaskContentAdapter.AbstractTaskContentAdapter<RequestBackendConfigType, StudipOauthAuthenticationHandler> {
 	getContentsForTask(task_id: string): Paginator<TaskContent, any> {
 		return new Paginator<TaskContent, any>((config) => {
-			return this.requestAdapter.getAuthorized(`plugins.php/argonautsplugin/tasks/${task_id}/contents`, config)
+			return this.requestAdapter.getAuthorized(`/tasks/${task_id}/contents`, config)
 		}, (data): TaskContent => {
 			return {
 				id: data.id,

--- a/packages/backend-adapter-argonauts/src/adapters/TaskContentQuestAdapter.ts
+++ b/packages/backend-adapter-argonauts/src/adapters/TaskContentQuestAdapter.ts
@@ -10,7 +10,7 @@ export default class TaskContentQuestAdapter<
 > extends NSTaskContentQuestAdapter.AbstractTaskContentQuestAdapter<RequestBackendConfigType, StudipOauthAuthenticationHandler> {
 	getQuestsForContent(content_id: string): Paginator<NSTaskContentQuestAdapter.TaskContentQuest, any> {
 		return new Paginator<TaskContentQuest, any>((config) => {
-			return this.requestAdapter.getAuthorized(`plugins.php/argonautsplugin/contents/${content_id}/quests`, config)
+			return this.requestAdapter.getAuthorized(`/contents/${content_id}/quests`, config)
 		}, (data): TaskContentQuest => {
 			return {
 				id: data.id,

--- a/packages/backend-adapter-argonauts/src/adapters/TaskContentQuestAnswerAdapter.ts
+++ b/packages/backend-adapter-argonauts/src/adapters/TaskContentQuestAnswerAdapter.ts
@@ -9,7 +9,7 @@ export default class TaskContentQuestAnswerAdapter<
 > extends NSTaskContentQuestAnswerAdapter.AbstractTaskContentQuestAnswerAdapter<RequestBackendConfigType, StudipOauthAuthenticationHandler> {
 	getAnswersForQuest(quest_id: string): Paginator<TaskContentQuestAnswer, any> {
 		return new Paginator<TaskContentQuestAnswer, any>((config) => {
-			return this.requestAdapter.getAuthorized(`plugins.php/argonautsplugin/quests/${quest_id}/answers`, config)
+			return this.requestAdapter.getAuthorized(`/quests/${quest_id}/answers`, config)
 		}, (data): TaskContentQuestAnswer => {
 			return {
 				id: data.id,

--- a/packages/backend-adapter-argonauts/src/adapters/UserAdapter.ts
+++ b/packages/backend-adapter-argonauts/src/adapters/UserAdapter.ts
@@ -26,7 +26,7 @@ export default class UserAdapter<
 > extends NSUserAdapter.AbstractUserAdapter<RequestBackendConfigType, StudipOauthAuthenticationHandler> {
 	async getInfo(user_id: string = "me"): Promise<UserInfo | undefined> {
 		try {
-			const { data } = await this.requestAdapter.get(`plugins.php/argonautsplugin/users/${user_id}`, {
+			const { data } = await this.requestAdapter.get(`/users/${user_id}`, {
 				auth: true
 			})
 

--- a/packages/backend-adapter-argonauts/src/adapters/UserTaskSolutionAdapter.ts
+++ b/packages/backend-adapter-argonauts/src/adapters/UserTaskSolutionAdapter.ts
@@ -12,8 +12,8 @@ export class UserTaskSolutionAdapter<RequestBackendConfigType> extends AbstractU
 		done_quests: string[]
 	}> {
 		const reqPath = solution_id
-			? `plugins.php/argonautsplugin/task_solutions/${solution_id}`
-			: `plugins.php/argonautsplugin/tasks/${task_id}/current_task_solution`
+			? `/task_solutions/${solution_id}`
+			: `/tasks/${task_id}/current_task_solution`
 
 		const { data } = await this.requestAdapter.getAuthorized(
 			reqPath,
@@ -66,7 +66,7 @@ export class UserTaskSolutionAdapter<RequestBackendConfigType> extends AbstractU
 		value: string
 	} | undefined> {
 		const { data } = await this.requestAdapter.postAuthorized(
-			`plugins.php/argonautsplugin/content_solutions`,
+			`/content_solutions`,
 			{
 				data: {
 					attributes: {
@@ -106,7 +106,7 @@ export class UserTaskSolutionAdapter<RequestBackendConfigType> extends AbstractU
 		sent_solution: boolean,
 	} | undefined> {
 		const { data } = await this.requestAdapter.postAuthorized(
-			`plugins.php/argonautsplugin/quest_solutions`,
+			`/quest_solutions`,
 			{
 				data: {
 					attributes: {},
@@ -168,7 +168,7 @@ export class UserTaskSolutionAdapter<RequestBackendConfigType> extends AbstractU
 		}[]
 	} | undefined> {
 		const { data } = await this.requestAdapter.getAuthorized(
-			`plugins.php/argonautsplugin/quest_solutions/${quest_solution_id}/sample_solution`
+			`/quest_solutions/${quest_solution_id}/sample_solution`
 		)
 
 		return data

--- a/packages/backend-adapter/package.json
+++ b/packages/backend-adapter/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@xyng/yuoshi-backend-adapter",
-	"version": "0.0.2-beta.0",
+	"version": "0.0.2-beta.1",
 	"description": "",
 	"repository": {
 		"type": "git",

--- a/packages/request-adapter-axios/package.json
+++ b/packages/request-adapter-axios/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@xyng/yuoshi-request-adapter-axios",
-	"version": "1.0.1-beta.0",
+	"version": "1.0.1-beta.1",
 	"description": "",
 	"repository": {
 		"type": "git",
@@ -24,7 +24,7 @@
 	"license": "MIT",
 	"dependencies": {
 		"@ungap/url-search-params": "^0.1.4",
-		"@xyng/yuoshi-backend-adapter": "^0.0.2-beta.0"
+		"@xyng/yuoshi-backend-adapter": "^0.0.2-beta.1"
 	},
 	"peerDependencies": {
 		"axios": "^0.19.1"


### PR DESCRIPTION
this moves removes references to plugin paths of the argonauts plugin.
They have to be provided by the Request-Adapter.